### PR TITLE
file extension mismatch was causing build errors

### DIFF
--- a/src/pages/GetInvolvedPage/GetInvolvedPage.js
+++ b/src/pages/GetInvolvedPage/GetInvolvedPage.js
@@ -14,7 +14,7 @@ import UISection from 'UILibrary/layout/UISection';
 import UIContentButton from 'UILibrary/button/UIContentButton';
 import UILayer from 'UILibrary/layer/UILayer';
 
-import donate2Image from './donate2.jpg';
+import donate2Image from './donate2.JPG';
 import heroImage from './hero.jpg';
 import mentorImage from './mentor.png';
 import studentImage from './student.png';


### PR DESCRIPTION
The file was looking for .jpg (note, in lowercase) but could not find this as the only file of that name is .JPG (note, in uppercase). This caused the site not to build or reflect the changes that were made. Your changes should be live after I merge this update @RouguiFuta