### PR TITLE
Hack2019b links

### DIFF
--- a/src/pages/Bootcamp/Bootcamp.js
+++ b/src/pages/Bootcamp/Bootcamp.js
@@ -59,7 +59,7 @@ class Bootcamp extends PureComponent {
                     <UITextShadow text="01.">
                       Hackathons
                     </UITextShadow>
-                  </h2>
+                  </h2>every time you switch branches // start work that is based off of master branch, run `npm install node-sass@latest` as a quick and dirty fix for now. In the future, i'll make the permit fix for your device
                   <div className="divider" />
                   <p className="text-on-dark">
                     We run two hackathons before each Bootcamp, from which we recruit our students.
@@ -217,7 +217,7 @@ class Bootcamp extends PureComponent {
 
                   <UIButton
                     external={true}
-                    href="https://docs.google.com/a/resilientcoders.org/forms/d/1QFBGAe1viFKEl-n7SbAek5XnAGQ22hTLdYoBlAXOiOM/">
+                    href="https://www.eventbrite.com/e/resilient-coders-summer-bootcamp-hackathon-tickets-59074669928">
                     Sign up
                   </UIButton>
                 </UICard>

--- a/src/pages/Bootcamp/Bootcamp.js
+++ b/src/pages/Bootcamp/Bootcamp.js
@@ -297,7 +297,7 @@ class Bootcamp extends PureComponent {
                   </p>
                   <UIButton
                     external={true}
-                    href="https://docs.google.com/a/resilientcoders.org/forms/d/1QFBGAe1viFKEl-n7SbAek5XnAGQ22hTLdYoBlAXOiOM/">
+                    href="https://www.eventbrite.com/e/resilient-coders-summer-bootcamp-hackathon-tickets-59074669928">
                     Sign up
                   </UIButton>
                 </UICard>

--- a/src/pages/Bootcamp/Bootcamp.js
+++ b/src/pages/Bootcamp/Bootcamp.js
@@ -59,7 +59,7 @@ class Bootcamp extends PureComponent {
                     <UITextShadow text="01.">
                       Hackathons
                     </UITextShadow>
-                  </h2>every time you switch branches // start work that is based off of master branch, run `npm install node-sass@latest` as a quick and dirty fix for now. In the future, i'll make the permit fix for your device
+                  </h2>
                   <div className="divider" />
                   <p className="text-on-dark">
                     We run two hackathons before each Bootcamp, from which we recruit our students.


### PR DESCRIPTION
**Summary**
Updated sign up links to re-direct to eventbrite hackathon page instead of google docs form

**Buttons** 
<img width="1409" alt="Screen Shot 2019-03-19 at 5 51 43 PM" src="https://user-images.githubusercontent.com/11174351/54699262-132bc280-4b07-11e9-85c2-95fe8c43135e.png">

<img width="1399" alt="Screen Shot 2019-03-19 at 5 51 20 PM" src="https://user-images.githubusercontent.com/11174351/54699312-2474cf00-4b07-11e9-9959-f508f4068e80.png">

**Previous redirect**: https://docs.google.com/a/resilientcoders.org/forms/d/1QFBGAe1viFKEl-n7SbAek5XnAGQ22hTLdYoBlAXOiOM/edit?usp=drive_web

**New redirect**: https://www.eventbrite.com/e/resilient-coders-summer-bootcamp-hackathon-tickets-59074669928

**Url of bootcamp page**: http://www.resilientcoders.org/bootcamp

